### PR TITLE
Skate configuration.

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,13 +88,33 @@ values:
 ```
 
 ## Querying
+Construct a database object for your favorite data source:
+```kotlin
+val database = Database.create(
+  config = DatabaseConfig(
+    host = "localhost",
+    database = "local",
+    user = "local",
+    password = "local",
+    port = 5432,
+  ),
+  poolConfig = ConnectionPoolConfig(
+    maximumPoolSize = 2,
+    minimumIdle = 1,
+    maxLifetime = 300000,
+    connectionTimeout = 30000,
+    idleTimeout = 600000,
+  ),
+  jackson = jackson
+)
+```
 Executing generated SQL in the database just requires calling either `query` or `execute` depending on whether you want to observe the results.
 ```kotlin
 User::class
   .selectAll()
   .where(User::name.like("John %"))
-  .generate(psql)
-  .query(jdmiHandle, timeoutSeconds =  10)
+  .generate(db.dialect)
+  .query(db)
 ```
 ```kotlin
 List<User>(...)

--- a/docker-compose.ci.yml
+++ b/docker-compose.ci.yml
@@ -1,0 +1,25 @@
+version: '3.6'
+services:
+  db:
+    image: postgis/postgis:14-3.3
+    restart: always
+    environment:
+      POSTGRES_USER: local
+      POSTGRES_PASSWORD: local
+      POSTGRES_DB: local
+    networks:
+      - api_net
+    command: postgres -N 500
+    ports:
+      - 5432:5432
+    volumes:
+      - type: tmpfs
+        target: /var/lib/postgresql/data
+
+volumes:
+  cache:
+    driver: local
+
+networks:
+  api_net:
+    name: ci_net

--- a/module-core/build.gradle.kts
+++ b/module-core/build.gradle.kts
@@ -11,7 +11,10 @@ dependencies {
   implementation(Library.Jackson.core)
   implementation(Library.Jackson.kotlin)
   implementation(Library.Jackson.databind)
+
   implementation(Library.ApacheCommon.lang3)
+
+  implementation(Library.Database.hikari)
 
   testImplementation(Library.Testing.jupiter)
   testImplementation(Library.Testing.assertj)

--- a/module-core/src/main/kotlin/skate/Database.kt
+++ b/module-core/src/main/kotlin/skate/Database.kt
@@ -1,0 +1,241 @@
+package skate
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import org.jdbi.v3.core.Handle
+import org.jdbi.v3.core.Jdbi
+import org.jdbi.v3.core.kotlin.KotlinPlugin
+import org.jdbi.v3.core.kotlin.useSequence
+import org.jdbi.v3.core.statement.HashPrefixSqlParser
+import org.postgis.Geometry
+import org.postgis.MultiPolygon
+import org.postgis.Point
+import org.postgis.Polygon
+import skate.configuration.ConnectionPoolConfig
+import skate.configuration.DataSourceFactory
+import skate.configuration.DatabaseConfig
+import skate.configuration.JdbiConfigurator
+import skate.generator.DeleteStatement
+import skate.generator.Dialect
+import skate.generator.InsertStatement
+import skate.generator.SelectStatement
+import skate.generator.UpdateStatement
+import skate.internal.mapper.column.registerJson
+import skate.internal.mapper.column.registerPGArrays
+import skate.internal.mapper.column.registerPostgisGeometry
+
+/**
+ * A database abstraction layer that uses [Jdbi] under the hood
+ */
+interface Database {
+  /**
+   * The SQL dialect which is used to generate SQL statements
+   */
+  val dialect: Dialect
+
+  /**
+   * The default query timeout in seconds for all queries
+   */
+  val defaultQueryTimeoutSeconds: Int
+
+  /**
+   * The [Jdbi] instance
+   */
+  val jdbi: Jdbi
+
+  companion object {
+    /**
+     * Create a Skate [Database] instance
+     *
+     * @param config The database config
+     * @param poolConfig The config for the connection pool
+     * @param factory The factory to use to create a specific data source, defaults to [DataSourceFactory.HIKARI]
+     * @param dialect The SQL dialect to use, defaults to [Dialect.POSTGRESQL]
+     * @param configurator The [JdbiConfigurator] to use, defaults to [JdbiConfigurator.NOOP]
+     * @param jackson The [ObjectMapper] to use for JSONB serialization and deserialization
+     */
+    fun create(
+      config: DatabaseConfig,
+      poolConfig: ConnectionPoolConfig,
+      factory: DataSourceFactory = DataSourceFactory.HIKARI,
+      dialect: Dialect = Dialect.POSTGRESQL,
+      configurator: JdbiConfigurator = JdbiConfigurator.NOOP,
+      jackson: ObjectMapper
+    ): Database {
+      val dataSource = factory.create(config, poolConfig)
+      return object : Database {
+        override val dialect: Dialect = dialect
+        override val defaultQueryTimeoutSeconds: Int = configurator.queryTimeoutSeconds
+        override val jdbi: Jdbi = Jdbi.create(dataSource).apply {
+          installPlugin(KotlinPlugin())
+          registerPostgisGeometry<Geometry>()
+          registerPostgisGeometry<Point>()
+          registerPostgisGeometry<Polygon>()
+          registerPostgisGeometry<MultiPolygon>()
+          registerJson<Map<String, Any>>(jackson)
+          registerJson<LinkedHashMap<String, Any>>(jackson)
+          registerPGArrays()
+          setSqlParser(HashPrefixSqlParser())
+          configurator.configure(this)
+        }
+      }
+    }
+  }
+}
+
+inline fun <reified T : Any> Database.queryRaw(
+  sql: String,
+  values: List<Any>,
+  query: Query? = null,
+): List<T> {
+  return jdbi.queryRaw(sql, values, query, defaultQueryTimeoutSeconds)
+}
+
+inline fun <reified T : Any> SelectStatement.query(
+  context: Database,
+  timeoutSeconds: Int? = null
+): List<T> {
+  return context.jdbi.queryRaw(sql, values, query, timeoutSeconds ?: context.defaultQueryTimeoutSeconds)
+}
+
+inline fun <reified T : Any> SelectStatement.queryFirst(
+  context: Database,
+  timeoutSeconds: Int? = null
+): T? {
+  return query<T>(context, timeoutSeconds).firstOrNull()
+}
+
+inline fun <reified T : Any, K> SelectStatement.queryMap(
+  context: Database,
+  timeoutSeconds: Int? = null,
+  keySelector: (T) -> K
+): Map<K, T> {
+  return query<T>(context, timeoutSeconds).associateBy(keySelector)
+}
+
+inline fun <reified T : Any, K> SelectStatement.queryGroup(
+  context: Database,
+  timeoutSeconds: Int? = null,
+  keySelector: (T) -> K
+): Map<K, List<T>> {
+  return query<T>(context, timeoutSeconds).groupBy(keySelector)
+}
+
+inline fun <reified T : Any> SelectStatement.queryEach(
+  context: Database,
+  timeoutSeconds: Int? = null,
+  crossinline action: (T) -> Unit
+) {
+  return context.jdbi.useHandle<Exception> { handle ->
+    handle
+      .createQuery(sql)
+      .setQueryTimeout(timeoutSeconds ?: context.defaultQueryTimeoutSeconds)
+      .bindValues(values)
+      .mapResults<T>(query = null)
+      .useSequence { it.forEach(action) }
+  }
+}
+
+inline fun <reified T : Any> SelectStatement.queryEach(
+  context: Database,
+  fetchSize: Int,
+  timeoutSeconds: Int? = null,
+  crossinline action: (T) -> Unit
+) {
+  return context.jdbi.useHandle<Exception> { handle ->
+    handle
+      .createQuery(sql)
+      // To avoid big chunk of memory being fetched.
+      // This is useful for doing chunk streaming of results when exhausting memory could be a problem.
+      .setFetchSize(fetchSize)
+      // Allow concurrent update, this will allow the update methods to be called on the result
+      .concurrentUpdatable()
+      .setQueryTimeout(timeoutSeconds ?: context.defaultQueryTimeoutSeconds)
+      .bindValues(values)
+      .mapResults<T>(query = null)
+      .useSequence { it.forEach(action) }
+  }
+}
+
+inline fun <reified T : Any> InsertStatement<T>.query(
+  context: Database,
+  timeoutSeconds: Int? = null
+): List<T> {
+  return context.jdbi.withHandle<List<T>, Exception> {
+    query(it, timeoutSeconds ?: context.defaultQueryTimeoutSeconds)
+  }
+}
+
+inline fun <reified T : Any> InsertStatement<T>.queryFirst(
+  context: Database,
+  timeoutSeconds: Int? = null
+): T? {
+  return query(context, timeoutSeconds).firstOrNull()
+}
+
+inline fun <reified T : Any> UpdateStatement.query(
+  context: Database,
+  timeoutSeconds: Int? = null
+): List<T> {
+  // Can't be ::query like other in this file; no generic on UpdateStatement to drive type inference
+  return context.jdbi.withHandle<List<T>, Exception> {
+    query(it, timeoutSeconds ?: context.defaultQueryTimeoutSeconds)
+  }
+}
+
+inline fun <reified T : Any> UpdateStatement.queryFirst(
+  context: Database,
+  timeoutSeconds: Int? = null
+): T? {
+  return query<T>(context, timeoutSeconds).firstOrNull()
+}
+
+fun InsertStatement<*>.execute(
+  context: Database,
+  timeoutSeconds: Int? = null
+): Int {
+  return context.execute(timeoutSeconds) { handle, timeout ->
+    execute(handle, timeout)
+  }
+}
+
+fun UpdateStatement.execute(
+  context: Database,
+  timeoutSeconds: Int? = null
+): Int {
+  return context.execute(timeoutSeconds) { handle, timeout ->
+    execute(handle, timeout)
+  }
+}
+
+fun DeleteStatement.execute(
+  context: Database,
+  timeoutSeconds: Int? = null
+): Int {
+  return context.execute(timeoutSeconds) { handle, timeout ->
+    execute(handle, timeout)
+  }
+}
+
+private fun Database.execute(
+  timeoutSeconds: Int?,
+  handler: (Handle, Int) -> Int
+): Int {
+  return jdbi.withHandle<Int, Exception> {
+    handler(it, timeoutSeconds ?: defaultQueryTimeoutSeconds)
+  }
+}
+
+fun Database.executeRaw(
+  sql: String
+): IntArray {
+  return jdbi.withHandle<IntArray, Exception> { handle ->
+    handle.createScript(sql).execute()
+  }
+}
+
+fun Database.nextValue(
+  sequence: String
+): Long {
+  return jdbi.withHandle<Long, Exception> { it.nextValue(sequence, defaultQueryTimeoutSeconds) }
+}
+

--- a/module-core/src/main/kotlin/skate/QueryExtensions.kt
+++ b/module-core/src/main/kotlin/skate/QueryExtensions.kt
@@ -500,13 +500,12 @@ fun not(expression: Expression<Boolean>) =
 // Selection
 
 // We're manually duplicating syntax between KClass<T> and TableAlias<T>.  In the future, we should consider creating
-// some kind of a common base object or interface so the duplication isn't necessary; maybe add a 'from' method that
+// some kind of common base object or interface so the duplication isn't necessary; maybe add a 'from' method that
 // wraps a KClass as a TableReference<T> or something...
-//
 // from<Nest>().select(...).where(...)
 
 inline fun <reified T : Any> KClass<T>.select(): Query {
-  val table = Table(T::class)
+  val table = Table(this)
   return Query(listOf(), listOf(), listOf(table))
 }
 
@@ -516,7 +515,7 @@ fun <T : Any> TableAlias<T>.select(): Query {
 }
 
 inline fun <reified T : Any> KClass<T>.select(vararg properties: KProperty1<T, *>): Query {
-  val table = Table(T::class)
+  val table = Table(this)
   return Query(properties.map { Projection(Column(it, table), null) }, listOf(), listOf(table))
 }
 
@@ -526,7 +525,7 @@ fun <T : Any> TableAlias<T>.select(vararg properties: KProperty1<T, *>): Query {
 }
 
 inline fun <reified T : Any> KClass<T>.select(vararg expressions: Expression<*>): Query {
-  val table = Table(T::class)
+  val table = Table(this)
   return Query(expressions.map { Projection(it, null) }, listOf(), listOf(table))
 }
 
@@ -536,7 +535,7 @@ fun <T : Any> TableAlias<T>.select(vararg expressions: Expression<*>): Query {
 }
 
 inline fun <reified T : Any> KClass<T>.select(vararg projections: Projection): Query {
-  val table = Table(T::class)
+  val table = Table(this)
   return Query(projections.toList(), listOf(), listOf(table))
 }
 
@@ -546,7 +545,7 @@ fun <T : Any> TableAlias<T>.select(vararg projections: Projection): Query {
 }
 
 inline fun <reified T : Any> KClass<T>.select(vararg aggregates: Aggregate): Query {
-  val table = Table(T::class)
+  val table = Table(this)
   return Query(listOf(), aggregates.toList(), listOf(table))
 }
 
@@ -556,12 +555,12 @@ fun <T : Any> TableAlias<T>.select(vararg aggregates: Aggregate): Query {
 }
 
 inline fun <reified T : Any> KClass<T>.selectAll(): Query {
-  val table = Table(T::class)
+  val table = Table(this)
   return Query(listOf(Projection(All(table))), listOf(), listOf(table))
 }
 
 inline fun <reified T : Any> KClass<T>.selectOne(): Query {
-  val table = Table(T::class)
+  val table = Table(this)
   return Query(listOf(Projection(Value(1))), listOf(), listOf(table))
 }
 
@@ -571,7 +570,7 @@ fun <T : Any> TableAlias<T>.selectAll(): Query {
 }
 
 inline fun <reified T : Any, reified U : Any> KClass<T>.selectAll(type: KClass<U>): Query {
-  val table = Table(T::class)
+  val table = Table(this)
   val propertyNames = type.memberProperties.filter { it.findAnnotation<Transient>() == null }.map { it.name }.toSet()
   val properties = T::class.memberProperties.filter { propertyNames.contains(it.name) }
   return Query(properties.map { Projection(Column(it, table), null) }, listOf(), listOf(table))
@@ -581,18 +580,18 @@ fun Query.distinct(): Query = copy(distinct = true)
 fun Query.random(): Query = copy(random = true)
 
 fun all() = All<Any>(null)
-inline fun <reified T : Any> KClass<T>.all() = All(Table(T::class))
+inline fun <reified T : Any> KClass<T>.all() = All(Table(this))
 
 fun projectAll() = Projection(all())
 inline fun <reified T : Any> KClass<T>.projectAll() = Projection(this.all())
 
 inline fun <reified T : Any> KClass<T>.selectCount(): Query {
-  val table = Table(T::class)
+  val table = Table(this)
   return Query(listOf(), listOf(countAll()), listOf(table))
 }
 
 inline fun <reified T : Any> KClass<T>.selectCountDistinct(property: KProperty1<T, *>, alias: String? = null): Query {
-  val table = Table(T::class)
+  val table = Table(this)
   val column = Column(property, table)
   return Query(listOf(), listOf(countDistinct(column, alias)), listOf(table))
 }

--- a/module-core/src/main/kotlin/skate/UpdateExtensions.kt
+++ b/module-core/src/main/kotlin/skate/UpdateExtensions.kt
@@ -11,7 +11,7 @@ import kotlin.reflect.full.memberProperties
 
 // Insert
 inline fun <reified T : Any> KClass<T>.insert(vararg properties: KProperty1<T, *>): InsertWithoutSource<T> {
-  val table = Table(T::class)
+  val table = Table(this)
   val insertProperties = if (properties.isEmpty()) {
     T::class.memberProperties.filter { it.findAnnotation<Transient>() == null }
   } else {
@@ -88,7 +88,7 @@ fun <T : Any> InsertConflictActionWithProjections<T>.generate(dialect: Dialect) 
 // with<Nest>().update(...).from(...).where(...)
 
 inline fun <reified T : Any> KClass<T>.update(vararg fields: UpdateField<T>?): UpdateWithoutWhere<T> {
-  val table = Table(T::class)
+  val table = Table(this)
   return UpdateWithoutWhere(table, listOfNotNull(*fields), EmptyUpdateFrom)
 }
 
@@ -98,7 +98,7 @@ inline fun <reified T : Any> TableAlias<T>.update(vararg fields: UpdateField<T>?
 }
 
 inline fun <reified T : Any> KClass<T>.updateAll(vararg fields: UpdateField<T>?): Update<T> {
-  val table = Table(T::class)
+  val table = Table(this)
   return Update(table, fields.filterNotNull(), null)
 }
 

--- a/module-core/src/main/kotlin/skate/configuration/ConnectionPoolConfig.kt
+++ b/module-core/src/main/kotlin/skate/configuration/ConnectionPoolConfig.kt
@@ -1,0 +1,14 @@
+package skate.configuration
+
+import java.util.concurrent.TimeUnit
+
+data class ConnectionPoolConfig(
+  val connectionTimeout: Long = TimeUnit.SECONDS.toMillis(30),
+  val maximumPoolSize: Int = 2,
+  val minimumIdle: Int = maximumPoolSize,
+  val maxLifetime: Long = TimeUnit.MINUTES.toMillis(30),
+  val idleTimeout: Long = TimeUnit.MINUTES.toMillis(10),
+  val leakDetectionThreshold: Long = 60_000L,
+  val transactionIsolation: String? = null
+)
+

--- a/module-core/src/main/kotlin/skate/configuration/DataSourceFactory.kt
+++ b/module-core/src/main/kotlin/skate/configuration/DataSourceFactory.kt
@@ -1,0 +1,57 @@
+package skate.configuration
+
+import com.zaxxer.hikari.HikariConfig
+import com.zaxxer.hikari.HikariDataSource
+import org.postgis.PGbox2d
+import org.postgis.PGbox3d
+import org.postgis.PGgeometry
+import org.postgresql.PGConnection
+import java.util.Properties
+import javax.sql.DataSource
+
+interface DataSourceFactory {
+  /**
+   * Create a [DataSource] from [databaseConfig] and [poolConfig]
+   *
+   * @param databaseConfig [DatabaseConfig] to use
+   * @param poolConfig [ConnectionPoolConfig] to use
+   */
+  fun create(databaseConfig: DatabaseConfig, poolConfig: ConnectionPoolConfig): DataSource
+
+  companion object {
+
+    val HIKARI = object : DataSourceFactory {
+
+      override fun create(databaseConfig: DatabaseConfig, poolConfig: ConnectionPoolConfig): DataSource {
+        val properties = Properties().apply {
+          setProperty("dataSourceClassName", "org.postgresql.ds.PGSimpleDataSource")
+          setProperty("dataSource.user", databaseConfig.user)
+          setProperty("dataSource.password", databaseConfig.password)
+          setProperty("dataSource.databaseName", databaseConfig.database)
+          setProperty("dataSource.serverName", databaseConfig.host)
+          setProperty("dataSource.prepareThreshold", databaseConfig.prepareThreshold.toString())
+          setProperty("dataSource.portNumber", databaseConfig.port.toString())
+        }
+        val source = HikariDataSource(HikariConfig(properties)).apply {
+          connectionTimeout = poolConfig.connectionTimeout
+          maximumPoolSize = poolConfig.maximumPoolSize
+          maxLifetime = poolConfig.maxLifetime
+          minimumIdle = poolConfig.minimumIdle
+          idleTimeout = poolConfig.idleTimeout
+          leakDetectionThreshold = poolConfig.leakDetectionThreshold
+          poolConfig.transactionIsolation?.let {
+            transactionIsolation = it
+          }
+        }
+        source.connection.use {
+          it.unwrap(PGConnection::class.java).apply {
+            addDataType("geometry", PGgeometry::class.java)
+            addDataType("box3d", PGbox3d::class.java)
+            addDataType("box2d", PGbox2d::class.java)
+          }
+        }
+        return source
+      }
+    }
+  }
+}

--- a/module-core/src/main/kotlin/skate/configuration/DatabaseConfig.kt
+++ b/module-core/src/main/kotlin/skate/configuration/DatabaseConfig.kt
@@ -1,0 +1,10 @@
+package skate.configuration
+
+data class DatabaseConfig(
+  val host: String,
+  val database: String,
+  val user: String,
+  val password: String? = null,
+  val prepareThreshold: Int = 0,
+  val port: Int = 5432
+)

--- a/module-core/src/main/kotlin/skate/configuration/JdbiConfigurator.kt
+++ b/module-core/src/main/kotlin/skate/configuration/JdbiConfigurator.kt
@@ -1,0 +1,28 @@
+package skate.configuration
+
+import org.jdbi.v3.core.Jdbi
+
+interface JdbiConfigurator {
+  /**
+   * Configure [Jdbi] instance
+   */
+  fun configure(jdbi: Jdbi): Jdbi
+
+  /**
+   * The default query timeout in seconds
+   */
+  val queryTimeoutSeconds: Int
+
+  /**
+   * Default [JdbiConfigurator] do nothing but return
+   */
+  object NOOP : JdbiConfigurator {
+
+    override fun configure(jdbi: Jdbi): Jdbi {
+      return jdbi
+    }
+
+    override val queryTimeoutSeconds: Int = 10
+  }
+}
+

--- a/module-core/src/main/kotlin/skate/internal/mapper/JoinSkateMapper.kt
+++ b/module-core/src/main/kotlin/skate/internal/mapper/JoinSkateMapper.kt
@@ -13,8 +13,9 @@ import kotlin.reflect.KClass
 internal typealias Column = Pair<Int, String>
 
 /**
- * We need a better way to extract cacheable fields from a [Query] in order to make this class
- * cacheable. For now we don't have a lot of raw query so it should be fine
+ * In order to make this class cacheable, we are seeking an improved approach for extracting cacheable
+ * fields from a [Query]. Currently, we have a limited number of raw queries, so the existing method should
+ * suffice for now. However, we recognize the need for a more robust solution in the long run.
  */
 internal class JoinSkateMapper<T : Any>(
   private val type: KClass<T>,

--- a/module-test/README.md
+++ b/module-test/README.md
@@ -1,0 +1,7 @@
+## module-test
+
+Contains various integration tests for *Skate*. To run it locally, install Docker and run:
+
+```bash
+"docker-compose -f ./docker-compose.ci.yml up -d"
+```

--- a/module-test/build.gradle.kts
+++ b/module-test/build.gradle.kts
@@ -1,0 +1,18 @@
+import co.bird.Library
+
+dependencies {
+  implementation(project(":module-api"))
+  implementation(project(":module-core"))
+
+  testImplementation(Library.Jackson.databind)
+  testImplementation(Library.Jackson.core)
+  testImplementation(Library.Jackson.kotlin)
+
+  testImplementation(Library.Testing.jupiter)
+  testImplementation(Library.Testing.assertj)
+  testImplementation(Library.Database.postgresql)
+}
+
+tasks.withType<Test> {
+  useJUnitPlatform()
+}

--- a/module-test/src/test/kotlin/skate/test/AbstractTest.kt
+++ b/module-test/src/test/kotlin/skate/test/AbstractTest.kt
@@ -1,0 +1,52 @@
+package skate.test
+
+import com.fasterxml.jackson.databind.DeserializationFeature
+import com.fasterxml.jackson.databind.MapperFeature
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.fasterxml.jackson.databind.PropertyNamingStrategies
+import com.fasterxml.jackson.databind.SerializationFeature
+import com.fasterxml.jackson.module.kotlin.registerKotlinModule
+import skate.Database
+import skate.configuration.ConnectionPoolConfig
+import skate.configuration.DatabaseConfig
+import skate.internal.mapper.column.jsonb.JavaTimeModule
+
+abstract class AbstractTest {
+
+  companion object {
+    val jackson: ObjectMapper = ObjectMapper().apply {
+      propertyNamingStrategy = PropertyNamingStrategies.SNAKE_CASE
+      configure(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS, false)
+      configure(SerializationFeature.WRITE_ENUMS_USING_TO_STRING, true)
+      configure(DeserializationFeature.READ_ENUMS_USING_TO_STRING, true)
+      configure(MapperFeature.ACCEPT_CASE_INSENSITIVE_ENUMS, true)
+      configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false)
+      registerKotlinModule()
+      registerModule(JavaTimeModule())
+      findAndRegisterModules()
+    }
+  }
+
+  /**
+   * This configuration is from docker-compose.yml
+   */
+  protected val db by lazy {
+    Database.create(
+      config = DatabaseConfig(
+        host = "localhost",
+        database = "local",
+        user = "local",
+        password = "local",
+        port = 5432,
+      ),
+      poolConfig = ConnectionPoolConfig(
+        maximumPoolSize = 2,
+        minimumIdle = 1,
+        maxLifetime = 300000,
+        connectionTimeout = 30000,
+        idleTimeout = 600000,
+      ),
+      jackson = jackson
+    )
+  }
+}

--- a/module-test/src/test/kotlin/skate/test/ArrayTest.kt
+++ b/module-test/src/test/kotlin/skate/test/ArrayTest.kt
@@ -1,0 +1,80 @@
+package skate.test
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import skate.TableName
+import skate.eq
+import skate.execute
+import skate.executeRaw
+import skate.generate
+import skate.generator.Postgresql
+import skate.insert
+import skate.queryFirst
+import skate.selectAll
+import skate.values
+import skate.where
+import java.util.UUID
+
+class ArrayTest : AbstractTest() {
+
+  private val dialect = Postgresql()
+
+  @BeforeEach
+  fun setUp() {
+    db.executeRaw(DROP_TABLE_SQL)
+    db.executeRaw(CREATE_TABLE_SQL)
+  }
+
+  @Test
+  fun `insert and query sanity check`() {
+    val entity = MyArrayEntity(
+      UUID.randomUUID(),
+      ints = listOf(1, 2),
+      longs = listOf(Long.MIN_VALUE, Long.MAX_VALUE),
+      floats = listOf(1.0f, 2.0f),
+      doubles = listOf(1.0, 2.0)
+    )
+
+    MyArrayEntity::class
+      .insert()
+      .values(entity)
+      .generate(dialect)
+      .execute(db)
+
+    val result = MyArrayEntity::class
+      .selectAll()
+      .where(MyArrayEntity::id eq entity.id)
+      .generate(dialect)
+      .queryFirst<MyArrayEntity>(db)
+
+    assertThat(entity).isEqualTo(result)
+  }
+
+  companion object {
+    private const val TABLE = "my_array_entity"
+    private const val CREATE_TABLE_SQL =
+      """
+        CREATE EXTENSION IF NOT EXISTS "uuid-ossp";
+        CREATE EXTENSION IF NOT EXISTS "postgis";
+        CREATE TABLE $TABLE (
+          id UUID NOT NULL PRIMARY KEY,
+          ints integer[] NOT NULL default array[]::integer[],
+          longs bigint[] NOT NULL default array[]::bigint[],
+          floats real[] NOT NULL default array[]::real[],
+          doubles double precision[] NOT NULL default array[]::double precision[]
+        );
+      """
+
+    private const val DROP_TABLE_SQL = "DROP TABLE IF EXISTS $TABLE;"
+  }
+
+  @TableName(TABLE)
+  data class MyArrayEntity(
+    val id: UUID,
+    val ints: List<Int> = listOf(),
+    val longs: List<Long> = listOf(),
+    val floats: List<Float> = listOf(),
+    val doubles: List<Double> = listOf()
+  )
+}

--- a/module-test/src/test/kotlin/skate/test/CaseTest.kt
+++ b/module-test/src/test/kotlin/skate/test/CaseTest.kt
@@ -1,0 +1,105 @@
+package skate.test
+
+import skate.TableName
+import skate.asc
+import skate.case
+import skate.cast
+import skate.column
+import skate.eq
+import skate.generate
+import skate.insert
+import skate.isIn
+import skate.orderBy
+import skate.selectAll
+import skate.then
+import skate.to
+import skate.update
+import skate.values
+import skate.where
+import java.util.UUID
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import skate.TypeSpec
+import skate.execute
+import skate.executeRaw
+import skate.query
+
+class CaseTest : AbstractTest() {
+
+  @BeforeEach
+  fun setUp() {
+    db.executeRaw(CREATE_TABLE_SQL)
+  }
+
+  @AfterEach
+  fun tearDown() {
+    db.executeRaw(DROP_TABLE_SQL)
+  }
+
+  @Test
+  fun `case statement can be used as an expression`() {
+    val one = CaseTestEntity(UUID.randomUUID(), "1")
+    val two = CaseTestEntity(UUID.randomUUID(), "2")
+    val three = CaseTestEntity(UUID.randomUUID(), "3")
+
+    insert(one, two, three)
+
+    CaseTestEntity::class
+      .update(
+        CaseTestEntity::name to case(
+          CaseTestEntity::name.eq("1").then(CaseTestEntity::id.column().cast(TypeSpec("text"))),
+          fallback = "fallback"
+        )
+      )
+      .where(
+        case(
+          CaseTestEntity::name.isIn(listOf("1", "2")).then(true)
+        )
+      )
+      .generate(db.dialect)
+      .execute(db)
+
+    val result = CaseTestEntity::class
+      .selectAll()
+      .orderBy(CaseTestEntity::name.asc())
+      .generate(db.dialect)
+      .query<CaseTestEntity>(db)
+
+    assertThat(result).isEqualTo(
+      listOf(
+        three,
+        one.copy(name = one.id.toString()),
+        two.copy(name = "fallback")
+      )
+    )
+  }
+
+  private fun insert(vararg entities: CaseTestEntity) {
+    CaseTestEntity::class
+      .insert()
+      .values(entities.toList())
+      .generate(db.dialect)
+      .execute(db)
+  }
+
+  companion object {
+    const val TABLE_NAME = "case_test_entities"
+    private const val CREATE_TABLE_SQL =
+      """
+        CREATE TABLE $TABLE_NAME (
+          id UUID NOT NULL PRIMARY KEY,
+          name TEXT NOT NULL
+        );
+      """
+
+    private const val DROP_TABLE_SQL = "DROP TABLE $TABLE_NAME;"
+  }
+
+  @TableName(TABLE_NAME)
+  data class CaseTestEntity(
+    val id: UUID,
+    val name: String
+  )
+}

--- a/module-test/src/test/kotlin/skate/test/DeleteTest.kt
+++ b/module-test/src/test/kotlin/skate/test/DeleteTest.kt
@@ -1,0 +1,121 @@
+package skate.test
+
+import skate.TableName
+import skate.delete
+import skate.eq
+import skate.generate
+import skate.insert
+import skate.selectAll
+import skate.values
+import skate.where
+import java.util.UUID
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import skate.execute
+import skate.executeRaw
+import skate.query
+import skate.queryFirst
+
+class DeleteTest : AbstractTest() {
+
+  @BeforeEach
+  fun setUp() {
+    db.executeRaw(CREATE_TABLE_SQL)
+  }
+
+  @AfterEach
+  fun tearDown() {
+    db.executeRaw(DROP_TABLE_SQL)
+  }
+
+  @Test
+  fun `insert and delete happy path`() {
+    val one = MyDeleteEntity(UUID.randomUUID(), "one")
+    val two = MyDeleteEntity(UUID.randomUUID(), "two")
+
+    insert(one)
+    insert(two)
+
+    assertThat(query(one.id)).isEqualTo(one)
+    assertThat(query(two.id)).isEqualTo(two)
+
+    MyDeleteEntity::class
+      .delete()
+      .where(MyDeleteEntity::id eq one.id)
+      .generate(db.dialect)
+      .execute(db)
+
+    assertThat(query(one.id)).isEqualTo(null)
+    assertThat(query(two.id)).isEqualTo(two)
+  }
+
+  @Test
+  fun `insert and delete many happy path`() {
+    val one = MyDeleteEntity(UUID.randomUUID(), "one")
+    val two = MyDeleteEntity(UUID.randomUUID(), "d")
+    val three = MyDeleteEntity(UUID.randomUUID(), "d")
+    val four = MyDeleteEntity(UUID.randomUUID(), "d")
+
+    insert(one)
+    insert(two)
+    insert(three)
+    insert(four)
+
+    assertThat(query("d")).hasSize(3)
+
+    MyDeleteEntity::class
+      .delete()
+      .where(MyDeleteEntity::name eq "d")
+      .generate(db.dialect)
+      .execute(db)
+
+    assertThat(query(two.id)).isEqualTo(null)
+    assertThat(query(three.id)).isEqualTo(null)
+    assertThat(query(four.id)).isEqualTo(null)
+    assertThat(query("d")).hasSize(0)
+  }
+
+  companion object {
+    private const val CREATE_TABLE_SQL =
+      """
+        CREATE TABLE my_delete_entity (
+          id UUID NOT NULL PRIMARY KEY,
+          name TEXT NOT NULL
+        );
+      """
+
+    private const val DROP_TABLE_SQL = "DROP TABLE my_delete_entity;"
+  }
+
+  private fun insert(any: MyDeleteEntity) {
+    MyDeleteEntity::class
+      .insert()
+      .values(any)
+      .generate(db.dialect)
+      .execute(db)
+  }
+
+  private fun query(id: UUID): MyDeleteEntity? {
+    return MyDeleteEntity::class
+      .selectAll()
+      .where(MyDeleteEntity::id eq id)
+      .generate(db.dialect)
+      .queryFirst(db)
+  }
+
+  private fun query(name: String): List<MyDeleteEntity> {
+    return MyDeleteEntity::class
+      .selectAll()
+      .where(MyDeleteEntity::name eq name)
+      .generate(db.dialect)
+      .query(db)
+  }
+
+  @TableName("my_delete_entity")
+  data class MyDeleteEntity(
+    val id: UUID,
+    val name: String
+  )
+}

--- a/module-test/src/test/kotlin/skate/test/JoinTest.kt
+++ b/module-test/src/test/kotlin/skate/test/JoinTest.kt
@@ -1,0 +1,105 @@
+package skate.test
+
+import skate.TableName
+import skate.all
+import skate.and
+import skate.coalesce
+import skate.column
+import skate.columnAs
+import skate.generate
+import skate.generator.Postgresql
+import skate.insert
+import skate.values
+import skate.where
+import java.util.UUID
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import skate.Value
+import skate.eq
+import skate.execute
+import skate.executeRaw
+import skate.groupBy
+import skate.join
+import skate.max
+import skate.on
+import skate.query
+import skate.select
+
+class JoinTest : AbstractTest() {
+
+  private val dialect = Postgresql()
+
+  @BeforeEach
+  fun setUp() {
+    db.executeRaw(CREATE_TABLE_SQL)
+  }
+
+  @AfterEach
+  fun tearDown() {
+    db.executeRaw(DROP_TABLE_SQL)
+  }
+
+  @Test
+  fun `join against subquery`() {
+    val b3 = Vehicle(model = "b3", distance = 100)
+
+    listOf(
+      b3,
+      // Ignored because lower distance than b3MaxDistance vehicle
+      b3.copy(id = UUID.randomUUID(), distance = 0),
+      // Ignored because B2 was not requested model
+      Vehicle(model = "b2", distance = 101)
+    ).let(::insert)
+
+    val result = Vehicle::class
+      .select(Vehicle::class.all())
+      .join(
+        Vehicle::class
+          .select(Vehicle::distance.max("distance"))
+          .where(Vehicle::model eq b3.model!!)
+          .groupBy(Vehicle::model)
+          .on(
+            on = and(
+              Vehicle::distance eq Vehicle::distance.columnAs("agg"),
+              coalesce(Vehicle::model.column(), Value("")) eq Vehicle::model.columnAs("agg")
+            ),
+            alias = "agg"
+          )
+      )
+      .generate(dialect)
+      .query<Vehicle>(db)
+
+    assertThat(result).isEqualTo(listOf(b3))
+  }
+
+  private fun insert(entities: List<Vehicle>) {
+    Vehicle::class
+      .insert()
+      .values(entities)
+      .generate(dialect)
+      .execute(db)
+  }
+
+  companion object {
+    const val TABLE_NAME = "vehicles"
+    private const val CREATE_TABLE_SQL =
+      """
+        CREATE TABLE $TABLE_NAME (
+          id UUID NOT NULL PRIMARY KEY,
+          distance INT NOT NULL,
+          model TEXT
+        );
+      """
+
+    private const val DROP_TABLE_SQL = "DROP TABLE $TABLE_NAME;"
+  }
+
+  @TableName(TABLE_NAME)
+  data class Vehicle(
+    val id: UUID = UUID.randomUUID(),
+    val distance: Int,
+    val model: String?
+  )
+}

--- a/module-test/src/test/kotlin/skate/test/JsonbTest.kt
+++ b/module-test/src/test/kotlin/skate/test/JsonbTest.kt
@@ -1,0 +1,81 @@
+package skate.test
+
+import com.fasterxml.jackson.core.type.TypeReference
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import org.postgis.Point
+import skate.TableName
+import skate.eq
+import skate.execute
+import skate.executeRaw
+import skate.generate
+import skate.insert
+import skate.internal.mapper.column.registerJson
+import skate.queryFirst
+import skate.selectAll
+import skate.values
+import skate.where
+import java.util.UUID
+
+class JsonbTest : AbstractTest() {
+
+  @BeforeEach
+  fun setUp() {
+    db.jdbi.registerJson(jackson, object : TypeReference<List<Location>>() {})
+    db.executeRaw(DROP_TABLE_SQL)
+    db.executeRaw(CREATE_TABLE_SQL)
+  }
+
+  @Test
+  fun `insert and query sanity check`() {
+    val entity = MyJsonbEntity(
+      UUID.randomUUID(),
+      locations = listOf(Location(), Location()),
+      location = Location(),
+      uuids = listOf(UUID.randomUUID(), UUID.randomUUID())
+    )
+
+    MyJsonbEntity::class
+      .insert()
+      .values(entity)
+      .generate(db.dialect)
+      .execute(db)
+
+    val result = MyJsonbEntity::class
+      .selectAll()
+      .where(MyJsonbEntity::id eq entity.id)
+      .generate(db.dialect)
+      .queryFirst<MyJsonbEntity>(db)
+
+    assertThat(entity).isEqualTo(result)
+  }
+
+  companion object {
+    private const val TABLE = "my_json_entity"
+    private const val CREATE_TABLE_SQL =
+      """
+        CREATE TABLE $TABLE (
+          id UUID NOT NULL PRIMARY KEY,
+          uuids uuid[] NOT NULL default array[]::uuid[],
+          locations jsonb DEFAULT '[]'::jsonb NOT NULL,
+          location jsonb DEFAULT '{}'::jsonb NOT NULL
+        );
+      """
+
+    private const val DROP_TABLE_SQL = "DROP TABLE IF EXISTS $TABLE;"
+  }
+
+  @TableName(TABLE)
+  data class MyJsonbEntity(
+    val id: UUID,
+    val uuids: List<UUID> = listOf(),
+    val locations: List<Location> = listOf(),
+    val location: Location = Location()
+  )
+
+  data class Location(
+    val id: UUID = UUID.randomUUID(),
+    val name: String = ""
+  )
+}

--- a/module-test/src/test/kotlin/skate/test/SelectCountDistinctTest.kt
+++ b/module-test/src/test/kotlin/skate/test/SelectCountDistinctTest.kt
@@ -1,0 +1,79 @@
+package skate.test
+
+import skate.TableName
+import skate.generate
+import skate.generator.Postgresql
+import skate.insert
+import skate.selectCountDistinct
+import skate.values
+import skate.where
+import java.util.UUID
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import skate.eq
+import skate.execute
+import skate.executeRaw
+import skate.queryFirst
+
+class SelectCountDistinctTest : AbstractTest() {
+
+  private val dialect = Postgresql()
+
+  @BeforeEach
+  fun setUp() {
+    db.executeRaw(CREATE_TABLE_SQL)
+  }
+
+  @AfterEach
+  fun tearDown() {
+    db.executeRaw(DROP_TABLE_SQL)
+  }
+
+  @Test
+  fun `insert and count`() {
+    val a = MyCountEntity(UUID.randomUUID(), "one")
+    val b = MyCountEntity(UUID.randomUUID(), "one")
+    val c = MyCountEntity(UUID.randomUUID(), "two")
+
+    insert(a)
+    insert(b)
+    insert(c)
+
+    val result = MyCountEntity::class
+      .selectCountDistinct(MyCountEntity::name)
+      .where(MyCountEntity::name eq "one")
+      .generate(dialect)
+      .queryFirst<Int>(db)
+
+    assertThat(result).isEqualTo(1)
+  }
+
+  private fun insert(any: MyCountEntity) {
+    MyCountEntity::class
+      .insert()
+      .values(any)
+      .generate(dialect)
+      .execute(db)
+  }
+
+  companion object {
+    const val TABLE_NAME = "my_count_entity"
+    private const val CREATE_TABLE_SQL =
+      """
+        CREATE TABLE $TABLE_NAME (
+          id UUID NOT NULL PRIMARY KEY,
+          name TEXT NOT NULL
+        );
+      """
+
+    private const val DROP_TABLE_SQL = "DROP TABLE $TABLE_NAME;"
+  }
+
+  @TableName(TABLE_NAME)
+  data class MyCountEntity(
+    val id: UUID,
+    val name: String
+  )
+}

--- a/module-test/src/test/kotlin/skate/test/SkateEnumTest.kt
+++ b/module-test/src/test/kotlin/skate/test/SkateEnumTest.kt
@@ -1,0 +1,484 @@
+package skate.test
+
+import skate.array
+import skate.contains
+import skate.eq
+import skate.generate
+import skate.insert
+import skate.test.SkateTestEnumStel.BAG
+import skate.test.SkateTestEnumStel.BAR
+import skate.test.SkateTestEnumStel.FOO
+import skate.nullable
+import skate.selectAll
+import skate.to
+import skate.update
+import skate.values
+import skate.where
+import java.util.UUID
+import org.assertj.core.api.Assertions.assertThat
+import org.jdbi.v3.core.Jdbi
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import skate.execute
+import skate.executeRaw
+import skate.internal.mapper.column.registerEnum
+import skate.query
+import skate.queryFirst
+
+enum class SkateTestEnumStew {
+  FOO,
+  BAR,
+  BAG;
+
+  override fun toString(): String = name.toLowerCase()
+}
+
+data class SkateTestEnumWrapper(
+  val id: UUID = UUID.randomUUID(),
+  val item: SkateTestEnumStew
+)
+
+enum class SkateTestEnumStnew {
+  FOO,
+  BAR,
+  BAG;
+
+  override fun toString(): String = name.toLowerCase()
+}
+
+data class SkateTestNullableEnumWrapper(
+  val id: UUID = UUID.randomUUID(),
+  val item: SkateTestEnumStnew?
+)
+
+enum class SkateTestEnumStel {
+  FOO,
+  BAR,
+  BAG;
+
+  override fun toString(): String = name.toLowerCase()
+}
+
+data class SkateTestEnumList(
+  val id: UUID = UUID.randomUUID(),
+  val items: List<SkateTestEnumStel> = emptyList()
+)
+
+enum class SkateTestEnumStnel {
+  FOO,
+  BAR,
+  BAG;
+
+  override fun toString(): String = name.toLowerCase()
+}
+
+data class SkateTestNullableEnumList(
+  val id: UUID = UUID.randomUUID(),
+  val items: List<SkateTestEnumStnel>? = null
+)
+
+class SkateEnumTest : AbstractTest() {
+
+  @BeforeEach
+  fun beforeEach() {
+    db.jdbi
+      .registerEnum<SkateTestEnumStnel>("skate_test_enum_stnel")
+      .registerEnum<SkateTestEnumStel>("skate_test_enum_stel")
+      .registerEnum<SkateTestEnumStnew>("skate_test_enum_stnew")
+      .registerEnum<SkateTestEnumStew>("skate_test_enum_stew")
+  }
+
+  @Test
+  fun `Insert and query and update with non-nullable enum column`() {
+    db.executeRaw(
+      """
+        DROP TABLE IF EXISTS skate_test_enum_wrapper;
+        DROP TYPE IF EXISTS skate_test_enum_stew;
+        CREATE TYPE skate_test_enum_stew AS ENUM ('foo', 'bar', 'bag');
+        CREATE TABLE skate_test_enum_wrapper (
+          id uuid NOT NULL DEFAULT uuid_generate_v4() PRIMARY KEY,
+          item skate_test_enum_stew NOT NULL
+        );
+      """.trimIndent()
+    )
+
+    try {
+      val a = SkateTestEnumWrapper(item = SkateTestEnumStew.FOO)
+      val b = SkateTestEnumWrapper(item = SkateTestEnumStew.BAR)
+      val c = SkateTestEnumWrapper(item = SkateTestEnumStew.BAG)
+
+      val count: Int = SkateTestEnumWrapper::class.insert()
+        .values(a, b, c)
+        .generate(db.dialect)
+        .execute(db)
+
+      assertThat(count).isEqualTo(3)
+
+      val loadedA = SkateTestEnumWrapper::class.selectAll()
+        .where(SkateTestEnumWrapper::id eq a.id)
+        .generate(db.dialect)
+        .queryFirst<SkateTestEnumWrapper>(db)
+
+      assertThat(loadedA).isNotNull()
+      assertThat(loadedA!!.id).isEqualTo(a.id)
+      assertThat(loadedA.item).isEqualTo(a.item)
+
+      val loadedB = SkateTestEnumWrapper::class.selectAll()
+        .where(SkateTestEnumWrapper::id eq b.id)
+        .generate(db.dialect)
+        .queryFirst<SkateTestEnumWrapper>(db)
+
+      assertThat(loadedB).isNotNull()
+      assertThat(loadedB!!.id).isEqualTo(b.id)
+      assertThat(loadedB.item).isEqualTo(b.item)
+
+      val loadedC = SkateTestEnumWrapper::class.selectAll()
+        .where(SkateTestEnumWrapper::id eq c.id)
+        .generate(db.dialect)
+        .queryFirst<SkateTestEnumWrapper>(db)
+
+      assertThat(loadedC).isNotNull()
+      assertThat(loadedC!!.id).isEqualTo(c.id)
+      assertThat(loadedC.item).isEqualTo(c.item)
+
+      val affected = SkateTestEnumWrapper::class
+        .update(
+          SkateTestEnumWrapper::item to SkateTestEnumStew.BAG
+        )
+        .where(SkateTestEnumWrapper::id eq a.id)
+        .generate(db.dialect)
+        .execute(db)
+
+      assertThat(affected).isEqualTo(1)
+
+      val reloadedA = SkateTestEnumWrapper::class.selectAll()
+        .where(SkateTestEnumWrapper::id eq a.id)
+        .generate(db.dialect)
+        .queryFirst<SkateTestEnumWrapper>(db)
+
+      assertThat(reloadedA).isNotNull()
+      assertThat(reloadedA!!.item).isEqualTo(SkateTestEnumStew.BAG)
+    } finally {
+      db.executeRaw(
+        """
+          DROP TABLE IF EXISTS skate_test_enum_wrapper;
+          DROP TYPE IF EXISTS skate_test_enum_stew;
+        """.trimIndent()
+      )
+    }
+  }
+
+  @Test
+  fun `Insert and query and update with nullable enum column`() {
+    db.executeRaw(
+      """
+        DROP TABLE IF EXISTS skate_test_nullable_enum_wrapper;
+        DROP TYPE IF EXISTS skate_test_enum_stnew;
+
+        CREATE TYPE skate_test_enum_stnew AS ENUM ('foo', 'bar', 'bag');
+        CREATE TABLE skate_test_nullable_enum_wrapper (
+          id uuid NOT NULL DEFAULT uuid_generate_v4() PRIMARY KEY,
+          item skate_test_enum_stnew NULL
+        );
+      """.trimIndent()
+    )
+
+    try {
+      val a = SkateTestNullableEnumWrapper(item = SkateTestEnumStnew.FOO)
+      val b = SkateTestNullableEnumWrapper(item = SkateTestEnumStnew.BAR)
+      val c = SkateTestNullableEnumWrapper(item = null)
+
+      val count: Int = SkateTestNullableEnumWrapper::class.insert()
+        .values(a, b, c)
+        .generate(db.dialect)
+        .execute(db)
+
+      assertThat(count).isEqualTo(3)
+
+      val loadedA = SkateTestNullableEnumWrapper::class.selectAll()
+        .where(SkateTestNullableEnumWrapper::id eq a.id)
+        .generate(db.dialect)
+        .queryFirst<SkateTestNullableEnumWrapper>(db)
+
+      assertThat(loadedA).isNotNull()
+      assertThat(loadedA!!.id).isEqualTo(a.id)
+      assertThat(loadedA.item).isEqualTo(a.item)
+
+      val loadedB = SkateTestNullableEnumWrapper::class.selectAll()
+        .where(SkateTestNullableEnumWrapper::id eq b.id)
+        .generate(db.dialect)
+        .queryFirst<SkateTestNullableEnumWrapper>(db)
+
+      assertThat(loadedB).isNotNull()
+      assertThat(loadedB!!.id).isEqualTo(b.id)
+      assertThat(loadedB.item).isEqualTo(b.item)
+
+      val loadedC = SkateTestNullableEnumWrapper::class.selectAll()
+        .where(SkateTestNullableEnumWrapper::id eq c.id)
+        .generate(db.dialect)
+        .queryFirst<SkateTestNullableEnumWrapper>(db)
+
+      assertThat(loadedC).isNotNull()
+      assertThat(loadedC!!.id).isEqualTo(c.id)
+      assertThat(loadedC.item).isEqualTo(c.item)
+
+      val affected = SkateTestNullableEnumWrapper::class
+        .update(
+          SkateTestNullableEnumWrapper::item to SkateTestEnumStnew.BAG
+        )
+        .where(SkateTestNullableEnumWrapper::id eq a.id)
+        .generate(db.dialect)
+        .execute(db)
+
+      assertThat(affected).isEqualTo(1)
+
+      val reloadedA = SkateTestNullableEnumWrapper::class.selectAll()
+        .where(SkateTestNullableEnumWrapper::id eq a.id)
+        .generate(db.dialect)
+        .queryFirst<SkateTestNullableEnumWrapper>(db)
+
+      assertThat(reloadedA).isNotNull()
+      assertThat(reloadedA!!.item).isEqualTo(SkateTestEnumStnew.BAG)
+
+      val affected2 = SkateTestNullableEnumWrapper::class
+        .update(
+          SkateTestNullableEnumWrapper::item.nullable() to null
+        )
+        .where(SkateTestNullableEnumWrapper::id eq b.id)
+        .generate(db.dialect)
+        .execute(db)
+
+      assertThat(affected2).isEqualTo(1)
+
+      val reloadedB = SkateTestNullableEnumWrapper::class.selectAll()
+        .where(SkateTestNullableEnumWrapper::id eq b.id)
+        .generate(db.dialect)
+        .queryFirst<SkateTestNullableEnumWrapper>(db)
+
+      assertThat(reloadedB).isNotNull()
+      assertThat(reloadedB!!.item).isNull()
+    } finally {
+      db.executeRaw(
+        """
+          DROP TABLE IF EXISTS skate_test_nullable_enum_wrapper;
+          DROP TYPE IF EXISTS skate_test_enum_stnew;
+        """.trimIndent()
+      )
+    }
+  }
+
+  @Test
+  fun `Insert and query and update with non-nullable enum array column`() {
+    db.executeRaw(
+      """
+        DROP TABLE IF EXISTS skate_test_enum_list;
+        DROP TYPE IF EXISTS skate_test_enum_stel;
+        CREATE TYPE skate_test_enum_stel AS ENUM ('foo', 'bar', 'bag');
+        CREATE TABLE skate_test_enum_list (
+          id uuid NOT NULL DEFAULT uuid_generate_v4() PRIMARY KEY,
+          items skate_test_enum_stel[] NOT NULL
+        );
+      """.trimIndent()
+    )
+
+    try {
+
+      val a = SkateTestEnumList(items = listOf(FOO))
+      val b = SkateTestEnumList(items = listOf(BAR, BAG))
+      val c = SkateTestEnumList(items = listOf())
+
+      val count: Int = SkateTestEnumList::class.insert()
+        .values(a, b, c)
+        .generate(db.dialect)
+        .execute(db)
+
+      assertThat(count).isEqualTo(3)
+
+      val loadedA = SkateTestEnumList::class.selectAll()
+        .where(SkateTestEnumList::id eq a.id)
+        .generate(db.dialect)
+        .queryFirst<SkateTestEnumList>(db)
+
+      assertThat(loadedA).isNotNull()
+      assertThat(loadedA!!.id).isEqualTo(a.id)
+      assertThat(loadedA.items).containsExactlyElementsOf(a.items)
+
+      val loadedB = SkateTestEnumList::class.selectAll()
+        .where(SkateTestEnumList::id eq b.id)
+        .generate(db.dialect)
+        .queryFirst<SkateTestEnumList>(db)
+
+      assertThat(loadedB).isNotNull()
+      assertThat(loadedB!!.id).isEqualTo(b.id)
+      assertThat(loadedB.items).isEqualTo(b.items)
+
+      val loadedC = SkateTestEnumList::class.selectAll()
+        .where(SkateTestEnumList::id eq c.id)
+        .generate(db.dialect)
+        .queryFirst<SkateTestEnumList>(db)
+
+      assertThat(loadedC).isNotNull()
+      assertThat(loadedC!!.id).isEqualTo(c.id)
+      assertThat(loadedC.items).isEqualTo(c.items)
+
+      // Test querying by containment
+      val loadedList = SkateTestEnumList::class.selectAll()
+        .where(SkateTestEnumList::items.contains(listOf(BAR)))
+        .generate(db.dialect)
+        .query<SkateTestEnumList>(db)
+
+      assertThat(loadedList).isNotNull
+      assertThat(loadedList.count()).isEqualTo(1)
+      assertThat(loadedList[0].id).isEqualTo(b.id)
+      assertThat(loadedList[0].items).isEqualTo(b.items)
+
+      // Test updating to a populated list
+      val affected = SkateTestEnumList::class
+        .update(
+          SkateTestEnumList::items to listOf(FOO, BAR, BAG).array()
+        )
+        .where(SkateTestEnumList::id eq loadedA.id)
+        .generate(db.dialect)
+        .execute(db)
+
+      assertThat(affected).isEqualTo(1)
+
+      // Test updating to an empty list
+      val affected2 = SkateTestEnumList::class
+        .update(
+          SkateTestEnumList::items to listOf<SkateTestEnumStel>().array()
+        )
+        .where(SkateTestEnumList::id eq loadedB.id)
+        .generate(db.dialect)
+        .execute(db)
+
+      assertThat(affected2).isEqualTo(1)
+
+      val loadedAll = SkateTestEnumList::class.selectAll()
+        .generate(db.dialect)
+        .query<SkateTestEnumList>(db)
+
+      assertThat(loadedAll).isNotNull
+      assertThat(loadedAll.count()).isEqualTo(3)
+      assertThat(loadedAll.single { it.id == loadedA.id }.items.count()).isEqualTo(3)
+      assertThat(loadedAll.single { it.id == loadedB.id }.items.count()).isEqualTo(0)
+    } finally {
+      db.executeRaw(
+        """
+          DROP TABLE IF EXISTS skate_test_enum_list;
+          DROP TYPE IF EXISTS skate_test_enum_stel;
+        """.trimIndent()
+      )
+    }
+  }
+
+  @Test
+  fun `Insert and query and update with nullable enum array column`() {
+    db.executeRaw(
+      """
+        DROP TABLE IF EXISTS skate_test_nullable_enum_list;
+        DROP TYPE IF EXISTS skate_test_enum_stnel;
+
+        CREATE TYPE skate_test_enum_stnel AS ENUM ('foo', 'bar', 'bag');
+        CREATE TABLE skate_test_nullable_enum_list (
+          id uuid NOT NULL DEFAULT uuid_generate_v4() PRIMARY KEY,
+          items skate_test_enum_stnel[] NULL
+        );
+      """.trimIndent()
+    )
+
+    try {
+      val a = SkateTestNullableEnumList(items = listOf())
+      val b = SkateTestNullableEnumList(items = listOf(SkateTestEnumStnel.BAR, SkateTestEnumStnel.BAG))
+      val c = SkateTestNullableEnumList(items = null)
+
+      val count: Int = SkateTestNullableEnumList::class.insert()
+        .values(a, b, c)
+        .generate(db.dialect)
+        .execute(db)
+
+      assertThat(count).isEqualTo(3)
+
+      val loadedA = SkateTestNullableEnumList::class.selectAll()
+        .where(SkateTestNullableEnumList::id eq a.id)
+        .generate(db.dialect)
+        .queryFirst<SkateTestNullableEnumList>(db)
+
+      assertThat(loadedA).isNotNull()
+      assertThat(loadedA!!.id).isEqualTo(a.id)
+      assertThat(loadedA.items).containsExactlyElementsOf(a.items)
+
+      val loadedB = SkateTestNullableEnumList::class.selectAll()
+        .where(SkateTestNullableEnumList::id eq b.id)
+        .generate(db.dialect)
+        .queryFirst<SkateTestNullableEnumList>(db)
+
+      assertThat(loadedB).isNotNull()
+      assertThat(loadedB!!.id).isEqualTo(b.id)
+      assertThat(loadedB.items).isEqualTo(b.items)
+
+      val loadedC = SkateTestNullableEnumList::class.selectAll()
+        .where(SkateTestNullableEnumList::id eq c.id)
+        .generate(db.dialect)
+        .queryFirst<SkateTestNullableEnumList>(db)
+
+      assertThat(loadedC).isNotNull()
+      assertThat(loadedC!!.id).isEqualTo(c.id)
+      assertThat(loadedC.items).isEqualTo(c.items)
+
+      // Test querying by containment
+      val loadedList = SkateTestNullableEnumList::class.selectAll()
+        .where(SkateTestNullableEnumList::items.contains(listOf(SkateTestEnumStnel.BAR)))
+        .generate(db.dialect)
+        .query<SkateTestNullableEnumList>(db)
+
+      assertThat(loadedList).isNotNull
+      assertThat(loadedList.count()).isEqualTo(1)
+      assertThat(loadedList[0].id).isEqualTo(b.id)
+      assertThat(loadedList[0].items).isEqualTo(b.items)
+
+      // Test updating to a value
+      val affected = SkateTestNullableEnumList::class
+        .update(
+          SkateTestNullableEnumList::items to listOf(
+            SkateTestEnumStnel.FOO,
+            SkateTestEnumStnel.BAR,
+            SkateTestEnumStnel.BAG
+          ).array()
+        )
+        .where(SkateTestNullableEnumList::id eq loadedA.id)
+        .generate(db.dialect)
+        .execute(db)
+
+      assertThat(affected).isEqualTo(1)
+
+      // Test updating to null
+      val affected2 = SkateTestNullableEnumList::class
+        .update(
+          SkateTestNullableEnumList::items.nullable() to null
+        )
+        .where(SkateTestNullableEnumList::id eq loadedB.id)
+        .generate(db.dialect)
+        .execute(db)
+
+      assertThat(affected2).isEqualTo(1)
+
+      val loadedAll = SkateTestNullableEnumList::class.selectAll()
+        .generate(db.dialect)
+        .query<SkateTestNullableEnumList>(db)
+
+      assertThat(loadedAll).isNotNull
+      assertThat(loadedAll.count()).isEqualTo(3)
+      assertThat(loadedAll.single { it.id == loadedA.id }.items).isNotNull
+      assertThat(loadedAll.single { it.id == loadedA.id }.items!!.count()).isEqualTo(3)
+      assertThat(loadedAll.single { it.id == loadedB.id }.items).isNull()
+    } finally {
+      db.executeRaw(
+        """
+          DROP TABLE IF EXISTS skate_test_nullable_enum_list;
+          DROP TYPE IF EXISTS skate_test_enum_stnel;
+        """.trimIndent()
+      )
+    }
+  }
+}

--- a/module-test/src/test/kotlin/skate/test/TransientTest.kt
+++ b/module-test/src/test/kotlin/skate/test/TransientTest.kt
@@ -1,0 +1,165 @@
+package skate.test
+
+import skate.ColumnName
+import skate.TableName
+import skate.Transient
+import skate.column
+import skate.eq
+import skate.from
+import skate.generate
+import skate.insert
+import skate.into
+import skate.leftJoin
+import skate.on
+import skate.to
+import skate.queryFirst
+import skate.returning
+import skate.selectAll
+import skate.update
+import skate.values
+import skate.where
+import java.util.UUID
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import skate.All
+import skate.IntoField
+import skate.Projection
+import skate.Table
+import skate.execute
+import skate.executeRaw
+import skate.query
+
+class TransientTest : AbstractTest() {
+
+  @BeforeEach
+  fun setUp() {
+    db.executeRaw(DROP_TABLE_SQL)
+    db.executeRaw(CREATE_TABLE_SQL)
+  }
+
+  companion object {
+    private const val CREATE_TABLE_SQL =
+      """
+        CREATE TABLE IF NOT EXISTS vehicle (
+          id UUID NOT NULL PRIMARY KEY,
+          code TEXT
+        );
+
+        CREATE TABLE IF NOT EXISTS vehicle_lifecycle (
+          id UUID NOT NULL PRIMARY KEY,
+          vehicle_id UUID NOT NULL,
+          status TEXT
+        );
+      """
+
+    private const val DROP_TABLE_SQL =
+      """
+        DROP TABLE IF EXISTS vehicle;
+        DROP TABLE IF EXISTS vehicle_lifecycle;
+      """
+  }
+
+  @Test
+  fun `insert with default value from non-null transient column`() {
+    val vehicle = Vehicle()
+    Vehicle::class
+      .insert()
+      .values(vehicle)
+      .generate((db.dialect))
+      .execute(db)
+
+    val lifecycle = VehicleLifecycle(vehicleId = vehicle.id)
+    VehicleLifecycle::class
+      .insert()
+      .values(lifecycle)
+      .generate((db.dialect))
+      .execute(db)
+
+    val result = Vehicle::class
+      .selectAll()
+      .where(Vehicle::id eq vehicle.id)
+      .leftJoin(
+        VehicleLifecycle::class
+          .selectAll()
+          .into(Vehicle::lifecycle)
+          .on(Vehicle::id eq VehicleLifecycle::vehicleId)
+      )
+      .generate((db.dialect))
+      .query<Vehicle>(db)
+      .first()
+
+    assertThat(result).isEqualTo(vehicle.copy(code = null, lifecycle = lifecycle))
+  }
+
+  @Test
+  fun `update record with join returns transient values`() {
+    val vehicle = Vehicle()
+    Vehicle::class
+      .insert()
+      .values(vehicle)
+      .generate((db.dialect))
+      .execute(db)
+
+    val lifecycle = VehicleLifecycle(vehicleId = vehicle.id, status = "available")
+    VehicleLifecycle::class
+      .insert()
+      .values(lifecycle)
+      .generate((db.dialect))
+      .execute(db)
+
+    val result = db.jdbi.withHandle<Vehicle, Exception> {
+      Vehicle::class
+        .update(Vehicle::code to "test")
+        .from(Table(VehicleLifecycle::class))
+        .where(Vehicle::id eq vehicle.id)
+        .returning(Projection(All(Table(Vehicle::class))))
+        .returning(IntoField(VehicleLifecycle::class, Vehicle::lifecycle.column()))
+        .generate((db.dialect))
+        .queryFirst(it, 5)
+    }
+
+    assertThat(result).isEqualTo(vehicle.copy(code = "test", lifecycle = lifecycle))
+  }
+
+  @Test
+  fun `update record returning different result set`() {
+    val vehicle = Vehicle()
+    Vehicle::class
+      .insert()
+      .values(vehicle)
+      .generate((db.dialect))
+      .execute(db)
+
+    val result = db.jdbi.withHandle<UUID, Exception> {
+      Vehicle::class
+        .update(Vehicle::code to "test")
+        .where(Vehicle::id eq vehicle.id)
+        .returning(Vehicle::id)
+        .generate((db.dialect))
+        .queryFirst(it, 5)
+    }
+    assertThat(result).isEqualTo(vehicle.id)
+  }
+
+  @TableName("vehicle_lifecycle")
+  data class VehicleLifecycle(
+    val id: UUID = UUID.randomUUID(),
+    val vehicleId: UUID = UUID.randomUUID(),
+    val status: String = "unknown"
+  )
+
+  @TableName("vehicle")
+  data class Vehicle(
+    val id: UUID = UUID.randomUUID(),
+
+    @ColumnName("code")
+    val nullableCode: String? = null,
+
+    @Transient
+    val code: String? = "hello",
+
+    @Transient
+    val lifecycle: VehicleLifecycle? = VehicleLifecycle(vehicleId = id, status = "unknown")
+  )
+}

--- a/module-test/src/test/kotlin/skate/test/UpsertTest.kt
+++ b/module-test/src/test/kotlin/skate/test/UpsertTest.kt
@@ -1,0 +1,140 @@
+package skate.test
+
+import skate.TableName
+import skate.doNothing
+import skate.eq
+import skate.generate
+import skate.insert
+import skate.onConflict
+import skate.selectAll
+import skate.selectCount
+import skate.update
+import skate.values
+import skate.where
+import java.util.UUID
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import skate.execute
+import skate.executeRaw
+import skate.queryFirst
+
+class UpsertIntegrationTest : AbstractTest() {
+
+  @BeforeEach
+  fun setUp() {
+    db.executeRaw(CREATE_TABLE_SQL)
+  }
+
+  @AfterEach
+  fun tearDown() {
+    db.executeRaw(DROP_TABLE_SQL)
+  }
+
+  @Test
+  fun `update on conflict inserts record if none exist`() {
+    val originalEntity = MyEntity(UUID.randomUUID(), "original")
+
+    MyEntity::class
+      .insert()
+      .values(originalEntity)
+      .onConflict(MyEntity::id).update(MyEntity::name)
+      .generate(db.dialect)
+      .execute(db)
+
+    val insertedEntity = MyEntity::class
+      .selectAll()
+      .where(MyEntity::id eq originalEntity.id)
+      .generate(db.dialect)
+      .queryFirst<MyEntity>(db)
+
+    assertEquals(originalEntity, insertedEntity)
+  }
+
+  @Test
+  fun `update on conflict updates record if one exists`() {
+    val originalEntity = MyEntity(UUID.randomUUID(), "original")
+    val updatedEntity = MyEntity(originalEntity.id, "updated")
+
+    MyEntity::class
+      .insert()
+      .values(originalEntity)
+      .generate(db.dialect)
+      .execute(db)
+
+    MyEntity::class
+      .insert()
+      .values(updatedEntity)
+      .onConflict(MyEntity::id).update(MyEntity::name)
+      .generate(db.dialect)
+      .execute(db)
+
+    val count = MyEntity::class
+      .selectCount()
+      .generate(db.dialect)
+      .queryFirst<Int>(db)
+
+    assertEquals(1, count)
+
+    val result = MyEntity::class
+      .selectAll()
+      .where(MyEntity::id eq originalEntity.id)
+      .generate(db.dialect)
+      .queryFirst<MyEntity>(db)
+
+    assertEquals(updatedEntity, result)
+  }
+
+  @Test
+  fun `do nothing on conflict leaves record alone`() {
+    val originalEntity = MyEntity(UUID.randomUUID(), "original")
+    val updatedEntity = MyEntity(originalEntity.id, "updated")
+
+    MyEntity::class
+      .insert()
+      .values(originalEntity)
+      .generate(db.dialect)
+      .execute(db)
+
+    MyEntity::class
+      .insert()
+      .values(updatedEntity)
+      .onConflict(MyEntity::id).doNothing()
+      .generate(db.dialect)
+      .execute(db)
+
+    val count = MyEntity::class
+      .selectCount()
+      .generate(db.dialect)
+      .queryFirst<Int>(db)
+
+    assertEquals(1, count)
+
+    val result = MyEntity::class
+      .selectAll()
+      .where(MyEntity::id eq originalEntity.id)
+      .generate(db.dialect)
+      .queryFirst<MyEntity>(db)
+
+    assertEquals(originalEntity, result)
+  }
+
+  companion object {
+    private const val CREATE_TABLE_SQL =
+      """
+        CREATE TABLE my_entity (
+          id UUID NOT NULL PRIMARY KEY,
+          name TEXT NOT NULL
+        );
+      """
+
+    private const val DROP_TABLE_SQL = "DROP TABLE my_entity;"
+  }
+}
+
+@TableName("my_entity")
+data class MyEntity(
+  val id: UUID,
+  val name: String
+)

--- a/module-test/src/test/kotlin/skate/test/ViewObjectTest.kt
+++ b/module-test/src/test/kotlin/skate/test/ViewObjectTest.kt
@@ -1,0 +1,147 @@
+package skate.test
+
+import skate.TableName
+import skate.alias
+import skate.columnAs
+import skate.eq
+import skate.generate
+import skate.generator.Postgresql
+import skate.insert
+import skate.into
+import skate.join
+import skate.leftJoin
+import skate.on
+import skate.select
+import skate.selectAll
+import skate.values
+import skate.where
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+import skate.execute
+import skate.executeRaw
+import skate.query
+import java.util.UUID
+
+class ViewObjectTest : AbstractTest() {
+
+  private val dialect = Postgresql()
+
+  @BeforeEach
+  fun setUp() {
+    db.executeRaw(DROP_TABLE_SQL)
+    db.executeRaw(CREATE_TABLE_SQL)
+  }
+
+  companion object {
+    private const val CREATE_TABLE_SQL =
+      """
+        CREATE TABLE IF NOT EXISTS incoming_transactions (
+          id UUID NOT NULL PRIMARY KEY,
+          gateway_transaction_id UUID,
+          stuff TEXT
+        );
+
+        CREATE TABLE IF NOT EXISTS incoming_gateway_transactions (
+          id UUID NOT NULL PRIMARY KEY,
+          gateway_transaction_id UUID,
+          more_stuff TEXT
+        );
+
+        CREATE TABLE IF NOT EXISTS provider_incoming_transactions (
+          id UUID NOT NULL PRIMARY KEY,
+          provider_user_id UUID NOT NULL
+        );
+      """
+
+    private const val DROP_TABLE_SQL =
+      """
+        DROP TABLE IF EXISTS incoming_transactions;
+        DROP TABLE IF EXISTS incoming_gateway_transactions;
+        DROP TABLE IF EXISTS provider_incoming_transactions;
+      """
+  }
+
+  @Test
+  fun test() {
+    val userId = UUID.randomUUID()
+    val pit = PaymentProviderIncomingTransaction(providerUserId = userId)
+
+    PaymentProviderIncomingTransaction::class
+      .insert()
+      .values(pit)
+      .generate(dialect)
+      .execute(db)
+
+    val igt = IncomingGatewayTransaction(gatewayTransactionId = pit.id)
+
+    IncomingGatewayTransaction::class
+      .insert()
+      .values(igt)
+      .generate(dialect)
+      .execute(db)
+
+    val ict = IncomingTransaction(gatewayTransactionId = igt.id)
+
+    IncomingTransaction::class
+      .insert()
+      .values(ict)
+      .generate(dialect)
+      .execute(db)
+
+    val result = IncomingTransaction::class.alias("ict")
+      .select()
+      .join(
+        IncomingTransaction::class
+          .selectAll()
+          .into(LedgerTransactionSources::incomingTransaction)
+          .on(IncomingTransaction::id eq IncomingTransaction::id.columnAs("ict"))
+      )
+      .leftJoin(
+        IncomingGatewayTransaction::class
+          .selectAll()
+          .into(LedgerTransactionSources::incomingGatewayTransaction)
+          .on(IncomingTransaction::gatewayTransactionId eq IncomingGatewayTransaction::id)
+      )
+      .leftJoin(
+        PaymentProviderIncomingTransaction::class
+          .selectAll()
+          .into(LedgerTransactionSources::paymentProviderIncomingTransaction)
+          .on(IncomingGatewayTransaction::gatewayTransactionId eq PaymentProviderIncomingTransaction::id)
+      )
+      .where(IncomingTransaction::id.columnAs("ict") eq ict.id)
+      .generate(dialect)
+      .query<LedgerTransactionSources>(db)
+      .first()
+
+    assertThat(result.incomingTransaction.id).isEqualTo(ict.id)
+    assertThat(result.incomingGatewayTransaction?.id).isEqualTo(igt.id)
+    assertThat(result.paymentProviderIncomingTransaction?.id).isEqualTo(pit.id)
+  }
+
+  data class LedgerTransactionSources(
+    val incomingTransaction: IncomingTransaction,
+    val incomingGatewayTransaction: IncomingGatewayTransaction? = null,
+    val paymentProviderIncomingTransaction: PaymentProviderIncomingTransaction? = null
+  )
+
+  @TableName("incoming_transactions")
+  data class IncomingTransaction(
+    val id: UUID = UUID.randomUUID(),
+    val gatewayTransactionId: UUID? = null,
+    val stuff: String? = null
+  )
+
+  @TableName("incoming_gateway_transactions")
+  data class IncomingGatewayTransaction(
+    val id: UUID = UUID.randomUUID(),
+    val gatewayTransactionId: UUID? = null,
+    val moreStuff: String? = null
+  )
+
+  @TableName("provider_incoming_transactions")
+  data class PaymentProviderIncomingTransaction(
+    val id: UUID = UUID.randomUUID(),
+    val providerUserId: UUID,
+  )
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -2,5 +2,6 @@ rootProject.name = 'skate'
 
 include(
   "module-core",
-  "module-api"
+  "module-api",
+  "module-test"
 )


### PR DESCRIPTION
- Incorporate the `Database` object to configure Skate with JDBI.
```kt
interface Database {
  val dialect: Dialect
  val queryTimeoutSeconds: Int
  val jdbi: Jdbi

  companion object {
    /**
     * Create a [Database] instance
     *
     * @param config The database config
     * @param poolConfig The config for the connection pool
     * @param factory The factory to use to create a specific data source, defaults to [DataSourceFactory.HIKARI]
     * @param dialect The SQL dialect to use, defaults to [Dialect.POSTGRESQL]
     * @param configurator The [JdbiConfigurator] to use, defaults to [JdbiConfigurator.NOOP]
     * @param jackson The [ObjectMapper] to use for JSONB serialization and deserialization
     */
    fun create(
      config: DatabaseConfig,
      poolConfig: ConnectionPoolConfig,
      factory: DataSourceFactory = DataSourceFactory.HIKARI,
      dialect: Dialect = Dialect.POSTGRESQL,
      configurator: JdbiConfigurator = JdbiConfigurator.NOOP,
      jackson: ObjectMapper
    ): Database {
      val dataSource = factory.create(config, poolConfig)
      return object : Database {
        override val dialect: Dialect = dialect
        override val queryTimeoutSeconds: Int = configurator.queryTimeoutSeconds
        override val jdbi: Jdbi = Jdbi.create(dataSource).apply {
          installPlugin(KotlinPlugin())
          registerPostgisGeometry<Geometry>()
          registerPostgisGeometry<Point>()
          registerPostgisGeometry<Polygon>()
          registerPostgisGeometry<MultiPolygon>()
          registerJson<Map<String, Any>>(jackson)
          registerJson<LinkedHashMap<String, Any>>(jackson)
          registerPGArrays()
          setSqlParser(HashPrefixSqlParser())
          configurator.configure(this)
        }
      }
    }
  }
}
```
- Add `module-test` which contains various integration tests against PostgreSQL docker-compose.